### PR TITLE
fix: /data folder should be accessible by user 1001

### DIFF
--- a/build/agent/Dockerfile.jdk11
+++ b/build/agent/Dockerfile.jdk11
@@ -11,6 +11,7 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 FROM maven:3.8.6-jdk-11
 COPY --from=builder /runner /bin/runner
 
+RUN mkdir -m 777 -p /data
 USER 1001
 
 # do no overwrite the entrypoint

--- a/build/agent/Dockerfile.jdk17
+++ b/build/agent/Dockerfile.jdk17
@@ -11,6 +11,7 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 FROM maven:3.8.5-openjdk-17
 COPY --from=builder /runner /bin/runner
 
+RUN mkdir -m 777 -p /data
 USER 1001
 
 # do no overwrite the entrypoint

--- a/build/agent/Dockerfile.jdk18
+++ b/build/agent/Dockerfile.jdk18
@@ -11,6 +11,7 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 FROM maven:3.8.6-openjdk-18
 COPY --from=builder /runner /bin/runner
 
+RUN mkdir -m 777 -p /data
 USER 1001
 
 # do no overwrite the entrypoint

--- a/build/agent/Dockerfile.jdk8
+++ b/build/agent/Dockerfile.jdk8
@@ -11,6 +11,7 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 FROM maven:3.8.6-openjdk-8
 COPY --from=builder /runner /bin/runner
 
+RUN mkdir -m 777 -p /data
 USER 1001
 
 # do no overwrite the entrypoint


### PR DESCRIPTION
## Pull request description 

/data folder is the one we are using to store the test code in. When the Fetcher wants to save test code in there, it is getting a permission error
Closes https://github.com/kubeshop/testkube/issues/2436

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-